### PR TITLE
fix: removed check for details-menu dom element as it seems to always exist

### DIFF
--- a/src/content-script.ts
+++ b/src/content-script.ts
@@ -55,14 +55,7 @@ import { isBodyWithReplies, isRepositoryDetails } from "./validations";
 		return;
 	}
 
-	const onOpenSavedRepliesButtonClick = async () => {
-		while (
-			!document.querySelector(
-				`markdown-toolbar details-menu[src="/settings/replies?context=issue"]`
-			)
-		) {
-			await new Promise((resolve) => setTimeout(resolve, 10));
-		}
+	const onOpenSavedRepliesButtonClick = () => {
 		// 6. Add the new replies to the saved reply dropdown
 		const replyCategoriesDetailsMenus = document.querySelectorAll(
 			`markdown-toolbar details-menu[src="/settings/replies?context=issue"]`


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to refined-saved-replies! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #6
- [x] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/refined-saved-replies/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/refined-saved-replies/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Removed the initial poll in `onOpenSavedRepliesButtonClick` that checks if the details-menu element exists before execution.
The element exists even on load, so the check is redundant
```
while (
	!document.querySelector(
		'markdown-toolbar details-menu[src="/settings/replies?context=issue"]'
	)
) {
	await new Promise((resolve) => setTimeout(resolve, 10));
}
```

