### PR TITLE
fix: account for URL location changes for script injecting

### DIFF
--- a/src/content-script.ts
+++ b/src/content-script.ts
@@ -154,3 +154,5 @@ async function main() {
 		onOpenSavedRepliesButtonClick
 	);
 }
+
+main()

--- a/src/content-script.ts
+++ b/src/content-script.ts
@@ -4,11 +4,29 @@ import Mustache from "mustache";
 import { createElement } from "./elements";
 import { isBodyWithReplies, isRepositoryDetails } from "./validations";
 
-(async function main() {
+runMainOnLocationMatch();
+
+document.addEventListener("soft-nav:end", () => {
+	runMainOnLocationMatch();
+});
+
+function runMainOnLocationMatch() {
+	if (/\/.+\/.+\/(issues|pull)\/.+/.test(window.location.pathname)) {
+		main().catch((error) => {
+			console.error("Oh no!", error);
+		});
+	}
+}
+
+async function main() {
+	const openSavedRepliesButton = document.getElementById(
+		"saved-reply-new_comment_field"
+	);
+
 	// 1. Is this an issue I can reply to?
 	// (if not, exit from the page)
-	const replySummary = document.getElementById("saved-reply-new_comment_field");
-	if (!replySummary) {
+	if (!openSavedRepliesButton) {
+		console.error("Couldn't find clicker");
 		return;
 	}
 
@@ -62,13 +80,6 @@ import { isBodyWithReplies, isRepositoryDetails } from "./validations";
 		| undefined;
 	if (!newCommentField) {
 		console.error("Couldn't find comment field");
-		return;
-	}
-	const openSavedRepliesButton = document.getElementById(
-		"saved-reply-new_comment_field"
-	);
-	if (!openSavedRepliesButton) {
-		console.error("Couldn't find clicker");
 		return;
 	}
 
@@ -155,6 +166,4 @@ import { isBodyWithReplies, isRepositoryDetails } from "./validations";
 		"click",
 		onOpenSavedRepliesButtonClick
 	);
-})().catch((error) => {
-	console.error("Oh no!", error);
-});
+}

--- a/src/content-script.ts
+++ b/src/content-script.ts
@@ -155,4 +155,6 @@ async function main() {
 	);
 }
 
-main()
+main().catch((error) => {
+	console.error("Oh no!", error);
+});

--- a/src/content-script.ts
+++ b/src/content-script.ts
@@ -4,19 +4,7 @@ import Mustache from "mustache";
 import { createElement } from "./elements";
 import { isBodyWithReplies, isRepositoryDetails } from "./validations";
 
-runMainOnLocationMatch();
-
-document.addEventListener("soft-nav:end", () => {
-	runMainOnLocationMatch();
-});
-
-function runMainOnLocationMatch() {
-	if (/\/.+\/.+\/(issues|pull)\/.+/.test(window.location.pathname)) {
-		main().catch((error) => {
-			console.error("Oh no!", error);
-		});
-	}
-}
+document.addEventListener("soft-nav:end", main);
 
 async function main() {
 	const openSavedRepliesButton = document.getElementById(
@@ -26,7 +14,6 @@ async function main() {
 	// 1. Is this an issue I can reply to?
 	// (if not, exit from the page)
 	if (!openSavedRepliesButton) {
-		console.error("Couldn't find clicker");
 		return;
 	}
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #155 
- [x] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/refined-saved-replies/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/refined-saved-replies/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Uses GitHub's `soft-nav:end` event to re-run `main` as needed.

<details>
<summary>Old PR description here</summary>
Due to GitHub complex navigation, the only way to detect URL change is to use history state updates which content-script URL matching is not capable of doing.

~Therefore, this PR uses `background.js` to decide when to inject `content-script.js`~

~To make this possible, `"tabs", "webNavigation", "scripting"` permissions were required.~

~Also had to change `manifest.json` according to Firefox and Chrome.~

### **Explanation**
~Explanation for using visited set.~

~`historyStateUpdates` is triggered multiple times for one navigation change. debounce or throttle didn't seem like a good fit.~

~The only caveat is this introduces an edge case when strictly clicking links back and forth between issues or pull (e.g issues -> pull -> issues) because it has been visited already.~

~Going back in history preserves the DOM including content-script DOM injection so no issues there.~


~Please leave PR open while we investigate ways to eliminate this edge case. 
I believe I can do this by searching the DOM for injected content-script.~
**I'm open to ideas!** 😊

### UPDATE:

Using MutationObserver to detect changes in DOM that results from URL location change (browser controlled content-script matches is unable to do).

To prevent repetition (in case of DOM changes or weird pathname behavior with GitHub UI) a footprint is set and verified.
</details>

### **Thank you for challenging me!**

I updated this PR with a solution that keeps permissions the same as before 😊
