### PR TITLE
perf: run two JSON API fetches in parallel

### DIFF
--- a/src/content-script.ts
+++ b/src/content-script.ts
@@ -2,8 +2,9 @@ import * as yaml from "js-yaml";
 import Mustache from "mustache";
 
 import { createElement } from "./elements.js";
+import { fetchAsJson } from "./fetchAsJson.js";
 import { getSoon } from "./getSoon.js";
-import { isBodyWithReplies, isRepositoryDetails } from "./validations.js";
+import { isBodyWithReplies, isRepositorySettings } from "./validations.js";
 
 // TODO: Add handling for a rejection
 // https://github.com/JoshuaKGoldberg/refined-saved-replies/issues/2
@@ -21,29 +22,27 @@ async function main() {
 		return;
 	}
 
-	// 2. Fetch the repository's default branch, to retrieve replies.yml from
 	const [, userOrOrganization, repository, , issueOrPR] =
 		window.location.pathname.split("/");
-	const repositoryDetails = (await (
-		await fetch(
+
+	// 2. Fetch the REST API's JSON descriptions of the item and the repository's settings
+	const [itemDetails, repositorySettings] = await Promise.all([
+		fetchAsJson(
+			`https://api.github.com/repos/${userOrOrganization}/${repository}/issues/${issueOrPR}`,
+		),
+		fetchAsJson(
 			`https://api.github.com/repos/${userOrOrganization}/${repository}`,
-		)
-	).json()) as unknown;
-	if (!isRepositoryDetails(repositoryDetails)) {
-		console.error("Invalid repository details:", repositoryDetails);
+		),
+	]);
+
+	if (!isRepositorySettings(repositorySettings)) {
+		console.error("Invalid repository details:", repositorySettings);
 		return;
 	}
 
-	const { default_branch: defaultBranch } = repositoryDetails;
+	const { default_branch: defaultBranch } = repositorySettings;
 
-	// 3. Fetch the REST API's JSON description of the item
-	const details = (await (
-		await fetch(
-			`https://api.github.com/repos/${userOrOrganization}/${repository}/issues/${issueOrPR}`,
-		)
-	).json()) as unknown;
-
-	// 4. Fetch the repository's .github/replies.yml
+	// 3. Fetch the repository's .github/replies.yml
 	const repliesUrl = `https://raw.githubusercontent.com/${userOrOrganization}/${repository}/${defaultBranch}/.github/replies.yml`;
 	const repliesResponse = await fetch(repliesUrl);
 
@@ -60,7 +59,7 @@ async function main() {
 
 	const repliesBody = await repliesResponse.text();
 
-	// 5. Parse the replies body as yml
+	// 4. Parse the replies body as yml
 	const repliesConfiguration = yaml.load(repliesBody);
 	if (!isBodyWithReplies(repliesConfiguration)) {
 		console.error("Invalid saved replies:", repliesConfiguration);
@@ -77,7 +76,7 @@ async function main() {
 	}
 
 	const onOpenSavedRepliesButtonClick = async () => {
-		// 7. Add the new replies to the saved reply dropdown
+		// 6. Add the new replies to the saved reply dropdown
 		const replyCategoriesDetailsMenus = await getSoon(() =>
 			document.querySelectorAll(`.Overlay-body .js-saved-reply-menu`),
 		);
@@ -101,7 +100,7 @@ async function main() {
 								createElement("span", {
 									children: [
 										createElement("span", {
-											children: [Mustache.render(reply.name, details)],
+											children: [Mustache.render(reply.name, itemDetails)],
 											className:
 												"ActionListItem-label ActionListItem-label--truncate",
 											"data-view-component": true,
@@ -113,7 +112,9 @@ async function main() {
 													"aria-hidden": true,
 													children: [
 														createElement("span", {
-															children: [Mustache.render(reply.body, details)],
+															children: [
+																Mustache.render(reply.body, itemDetails),
+															],
 															"data-view-component": true,
 														}),
 													],
@@ -217,7 +218,7 @@ async function main() {
 		);
 	};
 
-	// 6. Add a listener to modify the saved reply dropdown upon creation
+	// 5. Add a listener to modify the saved reply dropdown upon creation
 	openSavedRepliesButton.addEventListener(
 		"click",
 		// TODO: Add handling for a rejection

--- a/src/content-script.ts
+++ b/src/content-script.ts
@@ -40,9 +40,8 @@ async function main() {
 		return;
 	}
 
-	const { default_branch: defaultBranch } = repositorySettings;
-
 	// 3. Fetch the repository's .github/replies.yml
+	const { default_branch: defaultBranch } = repositorySettings;
 	const repliesUrl = `https://raw.githubusercontent.com/${userOrOrganization}/${repository}/${defaultBranch}/.github/replies.yml`;
 	const repliesResponse = await fetch(repliesUrl);
 

--- a/src/fetchAsJson.ts
+++ b/src/fetchAsJson.ts
@@ -1,0 +1,3 @@
+export async function fetchAsJson(...args: Parameters<typeof fetch>) {
+	return (await (await fetch(...args)).json()) as unknown;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,6 @@ export interface Reply {
 	name: string;
 }
 
-export interface RepositoryDetails {
+export interface RepositorySettings {
 	default_branch: string;
 }

--- a/src/validations.test.ts
+++ b/src/validations.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { isBodyWithReplies, isRepositoryDetails } from "./validations.js";
+import { isBodyWithReplies, isRepositorySettings } from "./validations.js";
 
 describe("isBodyWithReplies", () => {
 	test.each([
@@ -33,7 +33,7 @@ describe("isRepositoryDetails", () => {
 		[{ default_branch: undefined }, false],
 		[{ default_branch: "" }, true],
 	])("%s is %s", (input, expected) => {
-		const actual = isRepositoryDetails(input);
+		const actual = isRepositorySettings(input);
 
 		expect(actual).toBe(expected);
 	});

--- a/src/validations.ts
+++ b/src/validations.ts
@@ -1,4 +1,4 @@
-import { BodyWithReplies, Reply, RepositoryDetails } from "./types.js";
+import { BodyWithReplies, Reply, RepositorySettings } from "./types.js";
 
 export function isBodyWithReplies(data: unknown): data is BodyWithReplies {
 	return !!(
@@ -18,10 +18,12 @@ function isReply(data: unknown): data is Reply {
 	);
 }
 
-export function isRepositoryDetails(data: unknown): data is RepositoryDetails {
+export function isRepositorySettings(
+	data: unknown,
+): data is RepositorySettings {
 	return !!(
 		data &&
 		typeof data === "object" &&
-		typeof (data as Partial<RepositoryDetails>).default_branch === "string"
+		typeof (data as Partial<RepositorySettings>).default_branch === "string"
 	);
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #149
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/refined-saved-replies/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/refined-saved-replies/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Uses `Promise.all` and a new `fetchAsJson` helper to clean up the code a bit and run the two requests in parallel, rather than in series.