### PR TITLE
feat: indicate replies loading errors to the user

### DIFF
--- a/src/content-script.ts
+++ b/src/content-script.ts
@@ -34,11 +34,8 @@ async function main() {
 	const { defaultBranch, itemDetails } = settings;
 
 	// 3. Fetch the repository's .github/replies.yml configuration
-	const repliesConfiguration = await fetchRepliesConfiguration(
-		defaultBranch,
-		locator,
-	);
-	if (!repliesConfiguration) {
+	const repliesResult = await fetchRepliesConfiguration(defaultBranch, locator);
+	if (repliesResult.type !== "success") {
 		return;
 	}
 
@@ -72,7 +69,7 @@ async function main() {
 				}),
 			);
 
-			for (const reply of repliesConfiguration.replies) {
+			for (const reply of repliesResult.configuration.replies) {
 				const button = createElement("button", {
 					children: [
 						createElement("span", {

--- a/src/content-script.ts
+++ b/src/content-script.ts
@@ -35,7 +35,10 @@ async function main() {
 
 	// 3. Fetch the repository's .github/replies.yml configuration
 	const repliesResult = await fetchRepliesConfiguration(defaultBranch, locator);
-	if (repliesResult.type !== "success") {
+
+	// A missing replies.yml is normal (most repos don't have one), so stay quiet.
+	// An error, though, should be surfaced to the user in the dropdown below.
+	if (repliesResult.type === "notFound") {
 		return;
 	}
 
@@ -58,6 +61,12 @@ async function main() {
 				.filter((x): x is ParentNode => !!x),
 		);
 
+		if (replyCategoriesDetailsMenus.length === 0) {
+			console.error(
+				"Couldn't find the saved replies dropdown to add repository replies to.",
+			);
+		}
+
 		for (const replyCategoriesDetailsMenu of replyCategoriesDetailsMenus) {
 			replyCategoriesDetailsMenu.appendChild(
 				// TODO: Use the built-in GitHub design system, Primer!
@@ -68,6 +77,20 @@ async function main() {
 					id: "repository-replies-label",
 				}),
 			);
+
+			// If the replies couldn't be loaded, show a small indication instead
+			// of the replies so the user knows something went wrong.
+			if (repliesResult.type === "error") {
+				replyCategoriesDetailsMenu.appendChild(
+					createElement("div", {
+						children: [
+							`Couldn't load this repository's replies: ${repliesResult.message}`,
+						],
+						className: "px-3 py-2 color-fg-muted",
+					}),
+				);
+				continue;
+			}
 
 			for (const reply of repliesResult.configuration.replies) {
 				const button = createElement("button", {

--- a/src/fetchRepliesConfiguration.test.ts
+++ b/src/fetchRepliesConfiguration.test.ts
@@ -11,39 +11,42 @@ describe("fetchRepliesConfiguration", () => {
 		globalThis.console.error = mockError;
 	});
 
-	it("returns undefined and console errors when the fetch is not ok and status is not 404", async () => {
+	it("returns an error result and console errors when the fetch is not ok and status is not 404", async () => {
 		const statusText = "Oh no!";
 
 		mockFetch.mockResolvedValue({ ok: false, status: 500, statusText });
 
 		const actual = await fetchRepliesConfiguration("", "");
 
-		expect(actual).toBeUndefined();
+		expect(actual).toEqual({ message: statusText, type: "error" });
 		expect(mockError).toHaveBeenCalledWith(
 			"Non-ok response fetching replies:",
 			statusText,
 		);
 	});
 
-	it("returns undefined and does not console error when the fetch is not ok and status is 404", async () => {
+	it("returns a notFound result and does not console error when the fetch is not ok and status is 404", async () => {
 		mockFetch.mockResolvedValue({ ok: false, status: 404 });
 
 		const actual = await fetchRepliesConfiguration("", "");
 
-		expect(actual).toBeUndefined();
+		expect(actual).toEqual({ type: "notFound" });
 		expect(mockError).not.toHaveBeenCalled();
 	});
 
-	it("returns undefined and console errors when the fetch retrieves an invalid configuration", async () => {
+	it("returns an error result and console errors when the fetch retrieves an invalid configuration", async () => {
 		mockFetch.mockResolvedValue({ ok: true, text: () => "" });
 
 		const actual = await fetchRepliesConfiguration("", "");
 
-		expect(actual).toBeUndefined();
+		expect(actual).toEqual({
+			message: "Invalid saved replies configuration.",
+			type: "error",
+		});
 		expect(mockError).toHaveBeenCalledWith("Invalid saved replies:", undefined);
 	});
 
-	it("returns the configuration when fetch retrieves a valid configuration", async () => {
+	it("returns a success result when fetch retrieves a valid configuration", async () => {
 		const configuration = { replies: [] };
 		mockFetch.mockResolvedValue({
 			ok: true,
@@ -52,7 +55,7 @@ describe("fetchRepliesConfiguration", () => {
 
 		const actual = await fetchRepliesConfiguration("", "");
 
-		expect(actual).toEqual(configuration);
+		expect(actual).toEqual({ configuration, type: "success" });
 		expect(mockError).not.toHaveBeenCalled();
 	});
 });

--- a/src/fetchRepliesConfiguration.ts
+++ b/src/fetchRepliesConfiguration.ts
@@ -1,24 +1,32 @@
 import * as yaml from "js-yaml";
 
+import { BodyWithReplies } from "./types.js";
 import { isBodyWithReplies } from "./validations.js";
+
+export type RepliesConfigurationResult =
+	| { configuration: BodyWithReplies; type: "success" }
+	| { message: string; type: "error" }
+	| { type: "notFound" };
 
 export async function fetchRepliesConfiguration(
 	defaultBranch: string,
 	locator: string,
-) {
+): Promise<RepliesConfigurationResult> {
 	const repliesResponse = await fetch(
 		`https://raw.githubusercontent.com/${locator}/${defaultBranch}/.github/replies.yml`,
 	);
 
 	if (!repliesResponse.ok) {
-		if (repliesResponse.status !== 404) {
-			console.error(
-				"Non-ok response fetching replies:",
-				repliesResponse.statusText,
-			);
+		if (repliesResponse.status === 404) {
+			return { type: "notFound" };
 		}
 
-		return;
+		console.error(
+			"Non-ok response fetching replies:",
+			repliesResponse.statusText,
+		);
+
+		return { message: repliesResponse.statusText, type: "error" };
 	}
 
 	const repliesBody = await repliesResponse.text();
@@ -27,8 +35,9 @@ export async function fetchRepliesConfiguration(
 
 	if (!isBodyWithReplies(repliesConfiguration)) {
 		console.error("Invalid saved replies:", repliesConfiguration);
-		return;
+
+		return { message: "Invalid saved replies configuration.", type: "error" };
 	}
 
-	return repliesConfiguration;
+	return { configuration: repliesConfiguration, type: "success" };
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/refined-saved-replies/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/refined-saved-replies/blob/main/.github/CONTRIBUTING.md) were taken


## Overview

Surfaces errors loading a repository's `.github/replies.yml` to the user instead of failing silently, as requested in #2.

- `fetchRepliesConfiguration` now returns a typed result — `success`, `notFound`, or `error` — so callers can tell a missing file (a normal 404) apart from a real load/parse failure.
- When the configuration can't be loaded or parsed, a small indication is shown in the Saved Replies dropdown.
- A `console.error` is logged when the saved replies dropdown can't be found on a page where it's expected.
- A missing `replies.yml` (404) is still treated as normal — no indication is shown, to avoid noise on the many repositories that don't use this feature.

Existing unit tests were updated for the new result type; `pnpm test`, `pnpm lint`, and `pnpm tsc` all pass.

> Note: I wasn't able to verify this end-to-end on github.com because the Saved Replies UI appears to have changed — the `[data-show-dialog-id="saved_replies_menu_new_comment_field-dialog"]` element that `content-script.ts` looks for currently returns `null` on issue/PR pages, so the content script exits early before reaching this code. That looks like it affects the extension in general rather than this change specifically.

📨
